### PR TITLE
R3: hash bytes as served, remove canonicalization mandate

### DIFF
--- a/draft-hardt-aauth-r3.md
+++ b/draft-hardt-aauth-r3.md
@@ -317,7 +317,9 @@ The document MUST be served over HTTPS. The resource MUST require a valid HTTP M
 
 ## Content Addressing
 
-The R3 hash (`r3_s256`) is computed as the SHA-256 hash of the canonical JSON serialization ([@!RFC8785]) of the R3 document, base64url-encoded without padding.
+The R3 hash (`r3_s256`) is computed as the SHA-256 hash of the bytes of the R3 document as served by the resource, base64url-encoded without padding.
+
+The resource's serialization is the document. There is no canonicalization step — verifiers hash the bytes received over the wire, not a normalized form. Resources MUST serialize the R3 document once and serve those exact bytes verbatim on every request for the same `r3_uri`. Re-serialization between hash computation and serving (e.g. middleware that parses and re-stringifies JSON, CDN minification, response framework helpers that reorder keys) will produce different bytes and break hash verification. Resources that build R3 documents on the fly SHOULD persist the serialized bytes (e.g. in a key-value store keyed by `r3_uri` or `r3_s256`) rather than re-build the document per request.
 
 The `r3_s256` hash is the document's identity, not the URI. The AS caches documents by hash. If a resource updates the document at the same URI, existing auth tokens still reference the previous hash (which the AS has cached). New resource tokens reference the new hash. This enables:
 
@@ -383,7 +385,7 @@ When the AS receives a resource token containing `r3_uri` and `r3_s256`, it MUST
 
 1. Validate the resource token signature per AAuth Protocol ([@!I-D.hardt-aauth-protocol]).
 2. Fetch the R3 document at `r3_uri`. The AS MAY use a cached copy if the cache entry was stored with the same `r3_s256` value.
-3. Compute the SHA-256 hash of the fetched document using canonical JSON serialization ([@!RFC8785]) and compare it to `r3_s256`. If the hashes do not match, the AS MUST reject the resource token.
+3. Compute the SHA-256 hash of the bytes received and compare it to `r3_s256`. If the hashes do not match, the AS MUST reject the resource token.
 4. Record `r3_uri` and `r3_s256` in its audit log alongside the token issuance event, the agent identifier, and the timestamp.
 5. Use the `operations` section for policy evaluation.
 6. Include `r3_uri`, `r3_s256`, `r3_granted`, and (if applicable) `r3_conditional` in the issued auth token.


### PR DESCRIPTION
Closes #13

Changes the R3 hash to be computed over the bytes the resource serves, removing the RFC 8785 canonical JSON serialization requirement.

## Diff summary

**Content Addressing section** (around line 320):
- Hash is now computed over "the bytes of the R3 document as served by the resource"
- Adds an implementer-guidance paragraph: serialize once, store, serve verbatim. Flags common breakage (middleware re-stringification, CDN minification, framework helpers that reorder keys). Recommends persisting serialized bytes for resources that build R3 docs on the fly.

**AS Processing step 3** (around line 386):
- "Compute the SHA-256 hash of the bytes received" replaces the canonical-JSON-serialization phrasing.

## Why

Per discussion in #13: the resource is the authoritative source of bytes, and canonicalization libraries (RFC 8785) add an implementation dependency that's hard to get right. Hashing the served bytes avoids the canonicalization-drift class of bugs entirely.

Practical consequence for RSes: serialize the R3 document once, store those bytes (e.g. KV), serve them verbatim on every request for the same `r3_uri`. The reference implementation (`r3demo`) already follows this pattern.