### PR TITLE
Metadata: require issuer to match the URL it was fetched from

### DIFF
--- a/draft-hardt-aauth-protocol.md
+++ b/draft-hardt-aauth-protocol.md
@@ -2120,6 +2120,10 @@ The `jwks_uri`, `tos_uri`, `policy_uri`, `logo_uri`, and `logo_dark_uri` values 
 
 Participants publish metadata at well-known URLs ([@!RFC8615]) to enable discovery.
 
+When fetching a metadata document, implementations MUST verify that the `issuer` value in the document matches the URL the document was retrieved from (the URL minus the `/.well-known/{dwk}` suffix). If the values do not match, the metadata document MUST be rejected.
+
+This check prevents host-poisoned metadata: an attacker hosting a metadata document at one domain that claims an `issuer` of a different domain. Without it, a permissive verifier following the `jwks_uri` in such a document could end up trusting attacker-controlled keys for tokens claiming the impersonated issuer.
+
 ### Agent Server Metadata
 
 Published at `/.well-known/aauth-agent.json`:


### PR DESCRIPTION
Closes #12

Adds a normative MUST in the Metadata Documents section: when fetching a metadata document, implementations MUST verify that `issuer` matches the URL the document was retrieved from (less the `/.well-known/{dwk}` suffix). Mismatch → reject.

## Why

Without this check, a "host-poisoned metadata" attack is possible against permissive verifiers — an attacker hosts a metadata document at their own domain claiming a different `issuer`, and a verifier that follows `jwks_uri` from such a document could end up trusting attacker-controlled keys for tokens claiming the impersonated issuer.

RFC 8414 (OAuth Authorization Server Metadata) makes the analogous check normative for OAuth. Bringing the AAuth metadata spec into alignment.

## Diff scope

Two paragraphs added at the top of `## Metadata Documents`. Applies uniformly across agent server, resource, PS, and AS metadata since they all share the same well-known fetch pattern.