### PR TITLE
Discovery: follow same-eTLD+1 redirects when fetching metadata

### DIFF
--- a/draft-hardt-aauth-protocol.md
+++ b/draft-hardt-aauth-protocol.md
@@ -2120,6 +2120,14 @@ The `jwks_uri`, `tos_uri`, `policy_uri`, `logo_uri`, and `logo_dark_uri` values 
 
 Participants publish metadata at well-known URLs ([@!RFC8615]) to enable discovery.
 
+### Following Redirects {#metadata-redirects}
+
+When fetching a metadata document, implementations MUST follow HTTP redirects ([@!RFC9110], Section 15.4) to a target host within the same effective top-level domain plus one (eTLD+1) as the original URL. Implementations SHOULD NOT follow redirects to a different eTLD+1.
+
+This permits a deployment where the user-facing entry point and the canonical metadata host differ within the same registrable domain. For example, `https://example.com/.well-known/aauth-person.json` MAY redirect to `https://person.example.com/.well-known/aauth-person.json`, allowing either URL to serve as a valid discovery entry point.
+
+When a redirect has been followed, validation of the metadata document is performed against the **final** URL (after redirects), not the original. In particular, the `issuer` value in the document MUST match the post-redirect URL minus the `/.well-known/{dwk}` suffix. The `iss` claim in tokens issued by the server is also the post-redirect URL.
+
 ### Agent Server Metadata
 
 Published at `/.well-known/aauth-agent.json`:


### PR DESCRIPTION
Closes #14

Adds a `Following Redirects` subsection to `## Metadata Documents` defining HTTP redirect behavior during metadata discovery.

## What's normative

- Implementations MUST follow redirects within the same eTLD+1 as the original URL
- Implementations SHOULD NOT follow redirects to a different eTLD+1
- After redirect, validation (issuer match, `iss` claim) is performed against the **final** URL, not the original

## Why

Allows deployments where the user-facing entry point and the canonical metadata host differ within the same registrable domain. Concretely:

- User types `hello.coop`
- Metadata fetch hits `https://hello.coop/.well-known/aauth-person.json`
- Server returns 302 to `https://person.hello.coop/.well-known/aauth-person.json`
- Implementation follows (same eTLD+1)
- Document's `issuer` is `https://person.hello.coop` — matches post-redirect URL ✓

This works without protocol changes today only if implementations happen to follow redirects, and the issuer match works only if it's done against the post-redirect URL — both currently unspecified. This PR makes the behavior explicit and bounded.

## Cross-reference

The post-redirect issuer check ties in with #12 (require `metadata.issuer === fetched-URL`). PR #17 mandates the check; this PR clarifies it applies to the post-redirect URL.

## Diff scope

One new `### Following Redirects {#metadata-redirects}` subsection in the Metadata Documents section. Three short paragraphs.