### PR TITLE
R3 examples: switch from ES256 to EdDSA

### DIFF
--- a/draft-hardt-aauth-r3.md
+++ b/draft-hardt-aauth-r3.md
@@ -346,7 +346,7 @@ R3 extension claims:
 ```json
 {
   "typ": "resource+jwt",
-  "alg": "ES256",
+  "alg": "EdDSA",
   "kid": "resource-key-1"
 }
 ```
@@ -418,7 +418,7 @@ R3 extension claims:
 ```json
 {
   "typ": "auth+jwt",
-  "alg": "ES256",
+  "alg": "EdDSA",
   "kid": "as-key-1"
 }
 ```


### PR DESCRIPTION
Brings the R3 example JWT headers in line with the rest of the spec, which RECOMMENDS EdDSA throughout — protocol doc §5.2.2, §6.6.1, §7.1.4 all show EdDSA in their token examples. The two R3 header examples were the only remaining `ES256` references in the spec.

## Diff

Two-line change in `draft-hardt-aauth-r3.md`:
- `resource+jwt` example header: `"alg": "ES256"` → `"alg": "EdDSA"`
- `auth+jwt` example header: `"alg": "ES256"` → `"alg": "EdDSA"`

No normative changes — examples only.