### PR TITLE
README: add IETF and AAuth Slack links

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,11 +86,13 @@ Bootstrap ceremony for SaaS browser, SaaS mobile, and B2B SaaS agents. Defines t
 
 ## Links
 
-| Resource | Link |
-|----------|------|
-| **Website** | https://www.aauth.dev |
-| **Office Hours Calendar** | https://lu.ma/aauth |
-| **GitHub Repository** | https://github.com/dickhardt/AAuth |
+| Resource | Link | Description |
+|----------|------|-------------|
+| **Website** | https://www.aauth.dev | |
+| **Office Hours Calendar** | https://lu.ma/aauth | |
+| **GitHub Repository** | https://github.com/dickhardt/AAuth | |
+| **IETF Slack** | https://join.slack.com/t/ietf/shared_invite/zt-3wlnl6g9t-UF~rAQwk06nNJUM6QtaaPg | IETF `#aauth` channel for AAuth specification discussion and feedback. |
+| **AAuth Slack** | https://join.slack.com/t/aauth/shared_invite/zt-3wsxbrzfk-oYb3xNWVPLZICkXwuJpaDg | AAuth community Slack for implementation discussion and questions. |
 
 ## Building
 

--- a/README.md
+++ b/README.md
@@ -89,8 +89,8 @@ Bootstrap ceremony for SaaS browser, SaaS mobile, and B2B SaaS agents. Defines t
 | Resource | Link | Description |
 |----------|------|-------------|
 | **Website** | https://www.aauth.dev | |
-| **Office Hours Calendar** | https://lu.ma/aauth | Drop in to ask questions, share what you're building, or listen along. |
 | **GitHub Repository** | https://github.com/dickhardt/AAuth | |
+| **Office Hours Calendar** | https://lu.ma/aauth | Drop in to ask questions, share what you're building, or listen along. |
 | **IETF Slack** | https://join.slack.com/t/ietf/shared_invite/zt-3wlnl6g9t-UF~rAQwk06nNJUM6QtaaPg | IETF `#aauth` channel for AAuth specification discussion and feedback. |
 | **AAuth Slack** | https://join.slack.com/t/aauth/shared_invite/zt-3wsxbrzfk-oYb3xNWVPLZICkXwuJpaDg | AAuth community Slack for implementation discussion and questions. |
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Bootstrap ceremony for SaaS browser, SaaS mobile, and B2B SaaS agents. Defines t
 | Resource | Link | Description |
 |----------|------|-------------|
 | **Website** | https://www.aauth.dev | |
-| **Office Hours Calendar** | https://lu.ma/aauth | |
+| **Office Hours Calendar** | https://lu.ma/aauth | Drop in to ask questions, share what you're building, or listen along. |
 | **GitHub Repository** | https://github.com/dickhardt/AAuth | |
 | **IETF Slack** | https://join.slack.com/t/ietf/shared_invite/zt-3wlnl6g9t-UF~rAQwk06nNJUM6QtaaPg | IETF `#aauth` channel for AAuth specification discussion and feedback. |
 | **AAuth Slack** | https://join.slack.com/t/aauth/shared_invite/zt-3wsxbrzfk-oYb3xNWVPLZICkXwuJpaDg | AAuth community Slack for implementation discussion and questions. |

--- a/README.md
+++ b/README.md
@@ -91,8 +91,8 @@ Bootstrap ceremony for SaaS browser, SaaS mobile, and B2B SaaS agents. Defines t
 | **Website** | https://www.aauth.dev | |
 | **GitHub Repository** | https://github.com/dickhardt/AAuth | |
 | **Office Hours Calendar** | https://lu.ma/aauth | Drop in to ask questions, share what you're building, or listen along. |
-| **IETF Slack** | https://join.slack.com/t/ietf/shared_invite/zt-3wlnl6g9t-UF~rAQwk06nNJUM6QtaaPg | IETF `#aauth` channel for AAuth specification discussion and feedback. |
-| **AAuth Slack** | https://join.slack.com/t/aauth/shared_invite/zt-3wsxbrzfk-oYb3xNWVPLZICkXwuJpaDg | AAuth community Slack for implementation discussion and questions. |
+| **IETF Slack** | https://www.aauth.dev/ietf-slack | IETF `#aauth` channel for AAuth specification discussion and feedback. |
+| **AAuth Slack** | https://www.aauth.dev/slack | AAuth community Slack for implementation discussion and questions. |
 
 ## Building
 


### PR DESCRIPTION
## Summary
- Adds IETF `#aauth` Slack invite and AAuth community Slack invite to the Links table.
- Adds a `Description` column to the Links table for the new entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)