### PR TITLE
Protocol: use snake_case token names in diagrams for consistency

### DIFF
--- a/draft-hardt-oauth-aauth-protocol.md
+++ b/draft-hardt-oauth-aauth-protocol.md
@@ -315,7 +315,7 @@ Agent                                 Resource       PS
   | auth_token                           |            |
   |<--------------------------------------------------|
   |                                      |            |
-  | HTTPSig w/ auth token                |            |
+  | HTTPSig w/ auth_token                |            |
   | GET /api/documents                   |            |
   |------------------------------------->|            |
   |                                      |            |
@@ -354,7 +354,7 @@ Agent                                Resource   PS                    AS
   | auth_token                          |       |                      |
   |<--------------------------------------------|                      |
   |                                     |       |                      |
-  | HTTPSig w/ auth token               |       |                      |
+  | HTTPSig w/ auth_token               |       |                      |
   | GET /api/documents                  |       |                      |
   |------------------------------------>|       |                      |
   |                                     |       |                      |
@@ -2612,7 +2612,7 @@ See (#call-chaining) for normative requirements. Resource 1 acts as an agent, se
 Agent        Resource 1       Resource 2          PS
   |              |                |                 |
   | HTTPSig w/   |                |                 |
-  | auth token   |                |                 |
+  | auth_token   |                |                 |
   |------------->|                |                 |
   |              |                |                 |
   |              | HTTPSig w/     |                 |
@@ -2637,7 +2637,7 @@ Agent        Resource 1       Resource 2          PS
   |              |<---------------------------------|
   |              |                |                 |
   |              | HTTPSig w/     |                 |
-  |              | auth token     |                 |
+  |              | auth_token     |                 |
   |              |--------------->|                 |
   |              |                |                 |
   |              | 200 OK         |                 |
@@ -2699,7 +2699,7 @@ User      Agent       Resource 1      Resource 2    PS
   |         |          gets auth_token]    |          |
   |         |              |               |          |
   |         |              | HTTPSig w/    |          |
-  |         |              | auth token    |          |
+  |         |              | auth_token    |          |
   |         |              |-------------->|          |
   |         |              |               |          |
   |         |              | 200 OK        |          |

--- a/draft-hardt-oauth-aauth-protocol.md
+++ b/draft-hardt-oauth-aauth-protocol.md
@@ -254,7 +254,7 @@ The agent signs requests with its agent token (#agent-tokens). The resource veri
 ~~~ ascii-art
 Agent                                        Resource
   |                                             |
-  | HTTPSig w/ agent token                      |
+  | HTTPSig w/ agent_token                      |
   |-------------------------------------------->|
   |                                             |
   | 200 OK                                      |
@@ -269,7 +269,7 @@ The resource handles authorization itself — via interaction (#user-interaction
 ~~~ ascii-art
 Agent                                        Resource
   |                                             |
-  | HTTPSig w/ agent token                      |
+  | HTTPSig w/ agent_token                      |
   |-------------------------------------------->|
   |                                             |
   | 202 (interaction required)                  |
@@ -284,7 +284,7 @@ Agent                                        Resource
   | AAuth-Access: opaque-token                  |
   |<--------------------------------------------|
   |                                             |
-  | HTTPSig w/ agent token                      |
+  | HTTPSig w/ agent_token                      |
   | Authorization: AAuth opaque-token           |
   |-------------------------------------------->|
   |                                             |
@@ -300,14 +300,14 @@ The resource has no separate access server — it accepts identity claims from w
 ~~~ ascii-art
 Agent                                 Resource       PS
   |                                      |            |
-  | HTTPSig w/ agent token               |            |
+  | HTTPSig w/ agent_token               |            |
   | POST authorization_endpoint          |            |
   |------------------------------------->|            |
   |                                      |            |
   | resource_token (aud = PS URL)        |            |
   |<-------------------------------------|            |
   |                                      |            |
-  | HTTPSig w/ agent token               |            |
+  | HTTPSig w/ agent_token               |            |
   | POST token_endpoint                  |            |
   | w/ resource_token                    |            |
   |-------------------------------------------------->|
@@ -331,14 +331,14 @@ The resource has its own access server. The resource issues a resource token (#r
 ~~~ ascii-art
 Agent                                Resource   PS                    AS
   |                                     |       |                      |
-  | HTTPSig w/ agent token              |       |                      |
+  | HTTPSig w/ agent_token              |       |                      |
   | POST authorization_endpoint         |       |                      |
   |------------------------------------>|       |                      |
   |                                     |       |                      |
   | resource_token (aud = AS URL)       |       |                      |
   |<------------------------------------|       |                      |
   |                                     |       |                      |
-  | HTTPSig w/ agent token              |       |                      |
+  | HTTPSig w/ agent_token              |       |                      |
   | POST token_endpoint                 |       |                      |
   | w/ resource_token                   |       |                      |
   |-------------------------------------------->|                      |
@@ -403,7 +403,7 @@ The agent proposes a mission at the PS. The PS and user may clarify and refine b
 ~~~ ascii-art
 Agent                                     PS                        User
   |                                        |                          |
-  | HTTPSig w/ agent token                 |                          |
+  | HTTPSig w/ agent_token                 |                          |
   | POST mission_endpoint                  |                          |
   | proposal                               |                          |
   |--------------------------------------->|                          |
@@ -425,7 +425,7 @@ The agent includes the `AAuth-Mission` header when sending requests to resources
 ~~~ ascii-art
 Agent                                        Resource
   |                                             |
-  | HTTPSig w/ agent token                      |
+  | HTTPSig w/ agent_token                      |
   | AAuth-Mission: approver=...; s256=...       |
   | POST authorization_endpoint                 |
   |-------------------------------------------->|
@@ -443,7 +443,7 @@ When the agent believes the mission is complete, it proposes completion via the 
 ~~~ ascii-art
 Agent                                     PS                        User
   |                                        |                          |
-  | HTTPSig w/ agent token                 |                          |
+  | HTTPSig w/ agent_token                 |                          |
   | POST interaction_endpoint              |                          |
   | type=completion, summary               |                          |
   |--------------------------------------->|                          |
@@ -2616,7 +2616,7 @@ Agent        Resource 1       Resource 2          PS
   |------------->|                |                 |
   |              |                |                 |
   |              | HTTPSig w/     |                 |
-  |              | R1 agent token |                 |
+  |              | R1 agent_token |                 |
   |              | AAuth-Mission  |                 |
   |              |--------------->|                 |
   |              |                |                 |


### PR DESCRIPTION
## Summary
- Diagram code blocks mixed prose-style and snake_case token names; align on the snake_case form everywhere in diagrams.
- `agent token` → `agent_token` (11 occurrences) in identity-based, three-party, four-party, governance, and call-chaining diagrams.
- `auth token` → `auth_token` (5 occurrences) in three-party, four-party, call-chaining, and interaction-chaining diagrams.
- Matches how `agent_token`, `resource_token`, `upstream_token`, `bootstrap_token` are already written elsewhere in the same diagrams and in `draft-hardt-aauth-bootstrap.md`.
- Prose text outside diagrams is unchanged — natural-language "agent token" / "auth token" is preserved.

## Test plan
- [ ] `grep -nE "^  \|" draft-hardt-oauth-aauth-protocol.md | grep -iE "\b(agent token|auth token|resource token|upstream token|bootstrap token)\b"` returns no matches.
- [ ] Rebuild HTML/TXT and skim the diagrams to confirm column alignment is preserved (each replacement is the same character count).

🤖 Generated with [Claude Code](https://claude.com/claude-code)