### PR TITLE
Update TypeScript implementation link to aauth-dev/packages-js

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ The authorization protocol for agent-to-resource access. Defines four resource a
 
 | Language | Repository |
 |----------|------------|
-| TypeScript | [github.com/hellocoop/AAuth](https://github.com/hellocoop/AAuth) |
+| TypeScript | [github.com/aauth-dev/packages-js](https://github.com/aauth-dev/packages-js) |
 | Python | [github.com/christian-posta/aauth-full-demo](https://github.com/christian-posta/aauth-full-demo) |
 | Java (Keycloak) | [github.com/christian-posta/keycloak-aauth-extension](https://github.com/christian-posta/keycloak-aauth-extension) |
 

--- a/draft-hardt-oauth-aauth-protocol.md
+++ b/draft-hardt-oauth-aauth-protocol.md
@@ -2571,7 +2571,7 @@ This section records the status of known implementations of the protocol defined
 
 The following implementations are known:
 
-- **TypeScript** — [github.com/hellocoop/AAuth](https://github.com/hellocoop/AAuth). Organization: Hellō. Coverage: agent token issuance, HTTP Message Signatures, resource token exchange, PS token endpoint. Level of maturity: exploratory.
+- **TypeScript** — [github.com/aauth-dev/packages-js](https://github.com/aauth-dev/packages-js). Organization: Hellō. Coverage: agent token issuance, HTTP Message Signatures, resource token exchange, PS token endpoint. Level of maturity: exploratory.
 - **Python** — [github.com/christian-posta/aauth-full-demo](https://github.com/christian-posta/aauth-full-demo). Contact: Christian Posta. Coverage: agent-to-resource flows with Keycloak as AS. Level of maturity: exploratory.
 - **Java (Keycloak SPI)** — [github.com/christian-posta/keycloak-aauth-extension](https://github.com/christian-posta/keycloak-aauth-extension). Contact: Christian Posta. Coverage: AAuth access server extension for Keycloak 26.2.5. Level of maturity: exploratory.
 


### PR DESCRIPTION
## Summary

- TypeScript implementation moved from `hellocoop/AAuth` to `aauth-dev/packages-js`. Updates the implementations table in `README.md` and the Implementation Status section in `draft-hardt-oauth-aauth-protocol.md` to point to the new repo.

## Test plan

- [ ] Confirm the new link `https://github.com/aauth-dev/packages-js` resolves to the current TypeScript implementation
- [ ] Verify rendered Markdown in both files shows the updated link

🤖 Generated with [Claude Code](https://claude.com/claude-code)