### PR TITLE
Metadata: require issuer to match the URL it was fetched from

### DIFF
--- a/draft-hardt-oauth-aauth-protocol.md
+++ b/draft-hardt-oauth-aauth-protocol.md
@@ -2165,6 +2165,10 @@ The `jwks_uri`, `tos_uri`, `policy_uri`, `logo_uri`, and `logo_dark_uri` values 
 
 Participants publish metadata at well-known URLs ([@!RFC8615]) to enable discovery.
 
+When fetching a metadata document, implementations MUST verify that the `issuer` value in the document matches the URL the document was retrieved from (the URL minus the `/.well-known/{dwk}` suffix). If the values do not match, the metadata document MUST be rejected.
+
+This check prevents host-poisoned metadata: an attacker hosting a metadata document at one domain that claims an `issuer` of a different domain. Without it, a permissive verifier following the `jwks_uri` in such a document could end up trusting attacker-controlled keys for tokens claiming the impersonated issuer.
+
 ### Agent Provider Metadata
 
 Published at `/.well-known/aauth-agent.json`:


### PR DESCRIPTION
Closes #12

Reworks #17 onto the renamed protocol file `draft-hardt-oauth-aauth-protocol.md` (the original #17 targeted the pre-rename `draft-hardt-aauth-protocol.md` and can no longer merge).

Adds a normative MUST in the Metadata Documents section: when fetching a metadata document, implementations MUST verify that `issuer` matches the URL the document was retrieved from (less the `/.well-known/{dwk}` suffix), and reject on mismatch.

## Why

Without this check, a host-poisoned metadata attack is possible against permissive verifiers — an attacker hosts a metadata document at their own domain claiming a different `issuer`, and a verifier that follows `jwks_uri` could end up trusting attacker-controlled keys for tokens claiming the impersonated issuer. RFC 8414 makes the analogous check normative for OAuth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)