### PR TITLE
Add designated expert instructions for IANA registries

### DIFF
--- a/draft-hardt-aauth-r3.md
+++ b/draft-hardt-aauth-r3.md
@@ -651,7 +651,17 @@ This specification establishes the AAuth R3 Vocabulary Registry. The initial con
 | `urn:aauth:vocabulary:wsdl` | SOAP/WSDL | This document |
 | `urn:aauth:vocabulary:odata` | OData | This document |
 
-New values may be registered following the Specification Required policy ([@!RFC8126]).
+New values may be registered following the Specification Required policy ([@!RFC8126], Section 4.6).
+
+### Designated Expert Instructions
+
+Registration requests for the AAuth R3 Vocabulary Registry are evaluated by a designated expert appointed by the IESG. Registration requests should be sent to IANA, which will forward them to the designated expert. The expert is expected to respond within two weeks. Denials should include an explanation and, if applicable, suggestions for how the request could be revised to be successful.
+
+A registration request must include the proposed vocabulary URI, the interface type it describes, and a reference to the specification defining it. The designated expert should verify that:
+
+- The vocabulary URI follows the `urn:aauth:vocabulary:<name>` pattern, where `<name>` is a lowercase token using only lowercase letters, digits, and hyphen, and is not confusingly similar to an existing entry.
+- The referenced specification is stable and freely available, and defines how operation identifiers are derived from the interface description in sufficient detail that independent implementations produce the same identifiers for the same interface.
+- The vocabulary covers an interface type not already served by an existing entry, or provides clear justification for an alternative vocabulary for an existing interface type.
 
 # Implementation Status
 
@@ -668,6 +678,7 @@ There are currently no known implementations.
 - draft-hardt-aauth-r3-01
   - Added the OPTIONAL `account` field to the R3 document, carrying the `account` value the authorization endpoint request named, and recommended that `display` name the account in terms the person recognises — the value is an identifier in the resource's namespace and may be opaque, so a consent screen rendering it verbatim identifies nothing.
   - Corrected the JWT header examples: `alg` is `Ed25519` rather than the deprecated polymorphic `EdDSA`, `typ` values are `aa-resource+jwt` and `aa-auth+jwt` to match the media types the protocol spec registers, and the `cnf.jwk` carries the `alg` member now required of every conveyed key.
+  - IANA review feedback: added Designated Expert Instructions for the AAuth R3 Vocabulary Registry per RFC 8126 Section 4.5.
   - Added per-call proposals for conditional operations
   - Content addressing hashes the bytes as served; removed canonicalization
   - Defined composition when requested operations span multiple R3 documents

--- a/draft-hardt-oauth-aauth-protocol.md
+++ b/draft-hardt-oauth-aauth-protocol.md
@@ -3039,7 +3039,7 @@ This specification registers the following claims in the IANA "JSON Web Token Cl
 
 ## AAuth Requirement Value Registry
 
-This specification establishes the AAuth Requirement Value Registry. The registry policy is Specification Required ([@!RFC8126]).
+This specification establishes the AAuth Requirement Value Registry. The registry policy is Specification Required ([@!RFC8126], Section 4.6). See (#designated-expert-instructions) for instructions to the designated expert.
 
 | Value | Reference |
 |-------|-----------|
@@ -3052,7 +3052,7 @@ This specification establishes the AAuth Requirement Value Registry. The registr
 
 ## AAuth Capability Value Registry
 
-This specification establishes the AAuth Capability Value Registry. The registry policy is Specification Required ([@!RFC8126]).
+This specification establishes the AAuth Capability Value Registry. The registry policy is Specification Required ([@!RFC8126], Section 4.6). See (#designated-expert-instructions) for instructions to the designated expert.
 
 | Value | Reference |
 |-------|-----------|
@@ -3062,7 +3062,7 @@ This specification establishes the AAuth Capability Value Registry. The registry
 
 ## AAuth Platform Value Registry {#aauth-platform-value-registry}
 
-This specification establishes the AAuth Platform Value Registry, used as values of the `platform` request parameter sent to the PS token endpoint (#ps-token-endpoint). The registry policy is Specification Required ([@!RFC8126]).
+This specification establishes the AAuth Platform Value Registry, used as values of the `platform` request parameter sent to the PS token endpoint (#ps-token-endpoint). The registry policy is Specification Required ([@!RFC8126], Section 4.6). See (#designated-expert-instructions) for instructions to the designated expert.
 
 | Value | Description | Reference |
 |-------|-------------|-----------|
@@ -3071,6 +3071,20 @@ This specification establishes the AAuth Platform Value Registry, used as values
 | `desktop` | Native desktop application (macOS, Windows, Linux) | This document |
 | `workload` | Headless server-class workload (backend service, CI runner, scheduled job, edge function) | This document |
 | `self-hosted` | User-controlled deployment under a domain the user controls | This document |
+
+## Designated Expert Instructions {#designated-expert-instructions}
+
+Registration requests for the AAuth Requirement Value, AAuth Capability Value, and AAuth Platform Value registries are evaluated by a designated expert appointed by the IESG, using the Specification Required policy ([@!RFC8126], Section 4.6).
+
+Registration requests should be sent to IANA, which will forward them to the designated expert. The expert is expected to respond within two weeks. Denials should include an explanation and, if applicable, suggestions for how the request could be revised to be successful.
+
+A registration request must include the proposed value, a brief description of its meaning, and a reference to the specification defining it. The designated expert should verify that:
+
+- The referenced specification is stable and freely available, and describes the value's semantics in sufficient detail that interoperable, independent implementations are possible.
+- The proposed value is a lowercase token using only lowercase letters and hyphen, consistent with the registries' existing entries, and is not confusingly similar to an existing entry.
+- The registration does not duplicate the semantics of an existing entry without clear justification.
+- For the Requirement Value and Capability Value registries, the specification defines the protocol behavior expected of a party that declares or encounters the value, including how a party that does not understand the value behaves.
+- For the Platform Value registry, the value describes a distinct runtime context that is meaningful for display to a person at a consent screen or dashboard, and the description does not overstate the security properties the value conveys.
 
 ## URI Scheme Registration
 
@@ -3119,6 +3133,7 @@ The following implementations are known:
   - Required the JWK in a `cnf` claim to carry a fully-specified `alg`, in agent tokens and auth tokens alike, and updated the examples, which previously conveyed a JWK with no `alg` and would now be rejected.
   - Required every key published at an AAuth server's `jwks_uri` to carry `alg`. A discovered key has no other channel for it, so a JWKS that omits the member cannot be used even though [@!RFC7517] makes it OPTIONAL.
   - Required a verifier to select the key matching `kid` without requiring other JWKS members to be usable, so that an issuer can publish a post-quantum key alongside a classical one without breaking verifiers that implement only the latter.
+  - IANA review feedback: added Designated Expert Instructions for the AAuth Requirement Value, Capability Value, and Platform Value registries per RFC 8126 Section 4.5.
 
 - draft-hardt-oauth-aauth-protocol-09
   - Clarification chat: added a required `action` discriminator (`clarification_response` / `updated_request`) to the agent's POST responses on the pending URL, so the response type is explicit rather than inferred from key presence.


### PR DESCRIPTION
Fixes #54

Responds to IANA's pre-IETF-126 review, which asked for designated expert guidelines for the new Specification Required registries per RFC 8126 Section 4.5.

**draft-hardt-oauth-aauth-protocol:**
- Adds a **Designated Expert Instructions** section covering the AAuth Requirement Value, Capability Value, and Platform Value registries: submission via IANA, two-week expert response expectation, denial handling, required request contents, and review criteria — spec stability and sufficiency for interop, token syntax conformance, no confusing similarity or semantic duplication, defined behavior for parties that don't understand a value (Requirement/Capability), and meaningful runtime-context descriptions that don't overstate security properties (Platform).
- Cites RFC 8126 Section 4.6 where each Specification Required policy is invoked, with pointers to the expert instructions.
- Adds a Document History entry under -10.

**draft-hardt-aauth-r3:**
- Adds equivalent **Designated Expert Instructions** for the AAuth R3 Vocabulary Registry: URN pattern conformance, deterministic operation-identifier derivation so independent implementations produce the same identifiers, and one vocabulary per interface type unless an alternative is justified.
- Recorded under the unpublished -01 Document History entry.

The registry policies are unchanged (Specification Required) — these registries reference specs that need real interop detail, unlike simple error-code tokens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Z2ehDiWSSRXqec94VhEYE