### PR TITLE
Acknowledge issue and pull request contributors

### DIFF
--- a/draft-hardt-aauth-r3.md
+++ b/draft-hardt-aauth-r3.md
@@ -672,7 +672,7 @@ There are currently no known implementations.
 
 # Acknowledgments
 
-The author would like to thank reviewers for their feedback.
+The author would like to thank reviewers for their feedback, and Ben McAdams for a pull request correcting this document's reference to the AAuth Protocol specification.
 
 {backmatter}
 

--- a/draft-hardt-oauth-aauth-protocol.md
+++ b/draft-hardt-oauth-aauth-protocol.md
@@ -3051,7 +3051,7 @@ The following implementations are known:
 
 # Acknowledgments
 
-The author would like to thank reviewers for their feedback on concepts and earlier drafts, and contributors who raised issues and pull requests: Aaron Parecki, Christian Posta, Dasith Wijesiriwardena, Frederik Krogsdal Jacobsen, Jared Hanson, Jeoffrey Haeyaert, João André Marques, Joshua Gay, Karl McGuinness, Lukas Friman, Mark Hendrickson, Nate Barbettini, Nick Gamb, Paul Carleton, Rohan Harikumar, Sanjay Dalal, Scott Motte, Wils Dawson.
+The author would like to thank reviewers for their feedback on concepts and earlier drafts, and contributors who raised issues and pull requests: Aaron Parecki, Ben McAdams, Christian Posta, Danny Fuhriman, Dasith Wijesiriwardena, Frederik Krogsdal Jacobsen, Jared Hanson, Jeoffrey Haeyaert, João André Marques, Joshua Gay, Karl McGuinness, Ken Huang, Lukas Friman, Mark Hendrickson, Mayur Agnihotri, Nate Barbettini, Nick Gamb, Paul Carleton, Rohan Harikumar, Sanjay Dalal, Scott Motte, Wils Dawson, Zeeshan Khan, and the GitHub contributors hegu-1 and sdatapix.
 
 {backmatter}
 


### PR DESCRIPTION
**Stack 1 of 7.** Base: `main`.

Adds the GitHub issue and PR contributors not yet listed in the protocol draft's acknowledgments:

| Added | For |
|---|---|
| Ben McAdams | #53 |
| Danny Fuhriman | #48 |
| Ken Huang | #41, #49 |
| Mayur Agnihotri | #44 |
| Zeeshan Khan | #49 |
| hegu-1 | #22 |
| sdatapix | #51 |

R3's acknowledgment was a bare sentence; it now names Ben McAdams, whose PR corrects R3's reference to the protocol spec.

**Three names to check before publication:**

- **Ken Huang** — GitHub profile name is the org "DistributedApps.AI", not a person. Inferred from the handle `kenhuangus`.
- **hegu-1** and **sdatapix** — no usable real name on either profile (`hegu-1`'s display name is 何故; `sdatapix` has none set). Listed by handle rather than guessed, and kept out of the alphabetical run so they read as handles deliberately.
- `sdatapix` is **not** the Sanjay Dalal already listed — I did not conflate them, but if they are the same person the entry is a duplicate.

A parallel change is needed in the `signature-key` repo: **Thibault Meunier** authored PRs #26–#30 there, which shaped much of -08, and was not acknowledged at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011H2BBgoKc7DqXeme5yT9Ls