### PR TITLE
Add the account parameter for resources holding several accounts

### DIFF
--- a/draft-hardt-aauth-r3.md
+++ b/draft-hardt-aauth-r3.md
@@ -357,8 +357,9 @@ The document MUST be served over HTTPS. The resource MUST require a valid HTTP M
     { "tool": "create_calendar_event" },
     { "tool": "modify_calendar_event" }
   ],
+  "account": "dick@example.com",
   "display": {
-    "summary": "Create and modify events on your work calendar",
+    "summary": "Create and modify events on your work calendar (dick@example.com)",
     "implications": "Meetings can be scheduled or rescheduled. Existing events can be modified.",
     "data_accessed": "Event titles, times, attendees, and descriptions in the work calendar",
     "irreversible": "Sent meeting invitations cannot be unsent"
@@ -373,6 +374,10 @@ The document MUST be served over HTTPS. The resource MUST require a valid HTTP M
 **`vocabulary`** (REQUIRED). The vocabulary URI identifying how operations are expressed. MUST match one of the vocabularies the resource advertises in `r3_vocabularies`.
 
 **`operations`** (REQUIRED). An array of operations covered by this R3 document, using the vocabulary-specific structure defined in {{mcp-vocabulary}} through {{odata-vocabulary}}. This is the same format used in the agent's `r3_operations` request and in the auth token's `r3_granted` and `r3_conditional` claims.
+
+**`account`** (OPTIONAL). Present when the authorization endpoint request carried an `account` parameter ([@!I-D.hardt-aauth-protocol]), carrying that same value. It identifies which account at the resource this authorization covers.
+
+When `account` is present, the `display` section SHOULD name the account in terms the person recognises. The value itself is an identifier in the resource's namespace and may be opaque — a numeric company id, a workspace key — so a consent screen rendering it verbatim tells the person nothing about which of their accounts is being authorized. The resource holds the human-readable name and `display` is where it belongs; a PS renders `display` and is not expected to interpret `account`.
 
 **`display`** (RECOMMENDED). Human-readable descriptions of the consequences of granting this access. The resource describes what *it* does, not what the agent intends:
 
@@ -661,6 +666,7 @@ There are currently no known implementations.
 *Note: This section is to be removed before publishing as an RFC.*
 
 - draft-hardt-aauth-r3-01
+  - Added the OPTIONAL `account` field to the R3 document, carrying the `account` value the authorization endpoint request named, and recommended that `display` name the account in terms the person recognises — the value is an identifier in the resource's namespace and may be opaque, so a consent screen rendering it verbatim identifies nothing.
   - Corrected the JWT header examples: `alg` is `Ed25519` rather than the deprecated polymorphic `EdDSA`, `typ` values are `aa-resource+jwt` and `aa-auth+jwt` to match the media types the protocol spec registers, and the `cnf.jwk` carries the `alg` member now required of every conveyed key.
   - Added per-call proposals for conditional operations
   - Content addressing hashes the bytes as served; removed canonicalization

--- a/draft-hardt-oauth-aauth-protocol.md
+++ b/draft-hardt-oauth-aauth-protocol.md
@@ -621,6 +621,7 @@ A resource MAY publish an `authorization_endpoint` in its metadata. The agent se
 **Request parameters:**
 
 - `scope` (REQUIRED): A space-separated string of scope values the agent is requesting.
+- `account` (OPTIONAL): A string identifying which account at the resource the authorization is for, drawn from the resource's own account namespace (#account-binding).
 
 ```http
 POST /authorize HTTP/1.1
@@ -812,6 +813,7 @@ Payload:
 - `scope`: Requested scopes, as a space-separated string of scope values. Companion specifications MAY define alternative authorization claims that replace `scope`.
 
 Optional payload claims:
+- `account`: The account the authorization is for, echoing the `account` parameter of the request that produced this token (#account-binding).
 - `mission`: Mission reference (present when the resource is mission-aware and the agent sent an `AAuth-Mission` header). Contains:
   - `approver`: HTTPS URL of the entity that approved the mission
   - `s256`: SHA-256 hash of the approved mission JSON (base64url)
@@ -1699,6 +1701,7 @@ Conditional payload claims (at least one MUST be present):
 At least one of `sub` or `scope` MUST be present.
 
 Optional payload claims:
+- `account`: The account the authorization is for, copied from the resource token (#account-binding).
 - `mission`: Mission reference. Present when the auth token was issued in the context of a mission. Contains:
   - `approver`: HTTPS URL of the entity that approved the mission
   - `s256`: SHA-256 hash of the approved mission JSON (base64url)
@@ -2031,6 +2034,26 @@ Scopes appear in three places in the protocol:
 3. **Authorization endpoint request** (`scope`): The scope the agent is requesting from the resource.
 
 The PS evaluates requested scopes against mission context (if present) and user consent. The AS evaluates scopes against resource policy. Either party may narrow the granted scope.
+
+## Account Binding {#account-binding}
+
+A resource may hold more than one account for the same person — an AAuth-to-OAuth proxy where a user has connected several accounts at the upstream service, a SaaS product where someone belongs to several workspaces. Scope says what the agent may do; it does not say which of those accounts it may do it to.
+
+The OPTIONAL `account` parameter of the authorization endpoint request (#authorization-endpoint-request) binds an authorization to one of them. Its value is a string from the resource's own account namespace — an email address, a workspace identifier, a tenant id, whatever the resource already uses. This specification gives it no structure and no meaning; only the resource interprets it.
+
+When the request carried `account`, the resource echoes it as the `account` claim of the resource token, the PS or AS copies it into the auth token, and the resource enforces per-account access directly from the token it receives. Different accounts yield different auth tokens, so an auth token for one account grants nothing at another, and the audit trail records which account each authorization covered.
+
+The parameter selects; it does not hint. It is not `login_hint` ([@!OpenID.Core], Section 3.1.2.1), which is a hint about who to authenticate at the party receiving it. Nobody is being authenticated here — the account is already connected at the resource — and the value has to survive into the issued tokens as a claim rather than being consumed during a login. Overloading `login_hint` would also conflate the person logging in at their PS with the account being acted on at the resource, which are different things and may belong to different namespaces entirely.
+
+### Resolving the Account {#account-resolution}
+
+An agent knows which account to name only if it has been told. Where it has not, the resource MUST NOT enumerate the accounts it holds for the person. It responds with `requirement=interaction` (#requirement-responses) and the person selects at the resource, in their own session.
+
+Enumerating is unsafe for a reason that is easy to miss: at the authorization endpoint the resource has the agent's identity and no verified identity for the person, so it has nothing to gate disclosure on and nothing to key the list to. Returning a list on the strength of an agent token would disclose which accounts sit behind that agent to anyone presenting one. Even where the resource does know the person — on a request bearing an auth token — which of someone's accounts an agent may act on is a decision that belongs to the person rather than to the agent, and the interaction flow is where a person makes it.
+
+Once the person has selected, the agent holds the `account` value and sends it on subsequent authorization requests without further interaction. An agent operating under a mission that already names the account never interacts at all.
+
+A PS displaying an authorization for consent MAY show the `account` value, and a resource that wants the person to see something more legible than an opaque identifier — a workspace name rather than a numeric id — puts that in the `display` text of its R3 document ([@?I-D.hardt-aauth-r3]), which is the resource-controlled consent text. The `account` value itself stays the identifier the resource enforces on.
 
 ## Requirement Responses {#requirement-responses}
 
@@ -3080,6 +3103,7 @@ The following implementations are known:
 *Note: This section is to be removed before publishing as an RFC.*
 
 - draft-hardt-oauth-aauth-protocol-10
+  - Added (#account-binding): an OPTIONAL `account` parameter on the authorization endpoint request, echoed as an OPTIONAL claim in the resource token and copied into the auth token, binding an authorization to one of several accounts a resource may hold for the same person. The value is an opaque string in the resource's own namespace. Where the agent does not know which account to name, the resource returns `requirement=interaction` and the person selects at the resource; a resource MUST NOT enumerate a person's accounts to an agent, having nothing to gate that disclosure on at the authorization endpoint. Addresses issue #52.
   - Added (#approved-tools-accountability), stating that approved-tool actions MAY execute while the PS is unreachable, that the mission log is consequently not a complete record, and that granting `approved_tools` is a trust decision about offline accountability whose blast radius is what the granted tools can do offline. A PS needing complete coverage declines the grant and requires per-action permission calls. Addresses issue #49.
   - Added (#directed-sub-chaining): a downstream issuer MUST NOT copy a directed `sub` from an upstream token, MAY emit `sub` only from its own authenticated federation step, otherwise omits it and carries the agent and delegation facts alone, and never places a person identifier in `act`. Identity is `(iss, sub)`, so a value minted by one issuer for one audience means nothing under another, and reusing it defeats the pairwise separation directed identifiers exist to provide. Addresses issue #41.
   - Updated the delegation chain examples, which showed a single `sub` value carried unchanged across every hop and so illustrated the behaviour (#directed-sub-chaining) forbids.


### PR DESCRIPTION
**Stack 7 of 7.** Base: `approved-tools-offline` (#66). Fixes #52.

A resource may hold more than one account for the same person — an AAuth-to-OAuth proxy where a user has connected several upstream accounts, a SaaS product with several workspaces. Scope says what the agent may do, not *which account* it may do it to, so consent never named the account, the auth token spanned all of them, and the audit trail could not show which one an authorization covered.

### The mechanism

An OPTIONAL `account` parameter on the authorization endpoint request, echoed as an OPTIONAL claim in the resource token, copied into the auth token. The value is an opaque string in the resource's own namespace — an email address, a workspace id, a tenant key. Different accounts yield different auth tokens, so enforcement and audit are per-account.

It *selects* rather than hints, which is why it is not `login_hint`: nobody is being authenticated, the account is already connected at the resource, and the value must survive into the tokens as a claim.

R3 gains a matching OPTIONAL `account` field, with a recommendation that `display` name the account in terms the person recognises.

### Two things this deliberately does not do

**No account listing.** The original proposal had the resource reject with an error listing the connected accounts. That is dropped. At the authorization endpoint the resource has an agent identity and *no verified identity for the person* — so it has nothing to gate a disclosure on and nothing to key the list to, and returning one would disclose the accounts behind an agent to anyone presenting an agent token. Even where the resource does know the person, which of their accounts an agent may act on is a decision that belongs to the person. Unknown account now resolves via `requirement=interaction`, where the person selects in their own session at the resource.

**No structure on the value.** The implementation report in #52 proposed `{id, kind, label}`. Both extra members are dropped:

- `kind` existed solely to make the PS verified-email cross-check safe — and that check is removed here, since it produced a warning that fired constantly for legitimate reasons.
- `label` addressed consent-card legibility, but the human-readable name belongs in the R3 document's `display` text, which the resource controls and the PS already renders. The identifier stays an identifier.

Dropping the listing is what removes the last place a label would have been needed on the wire.

### Cost

First-time account selection takes an interaction round trip; afterwards the agent holds the value and sends it with no interaction. An agent under a mission that already names the account never pays it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011H2BBgoKc7DqXeme5yT9Ls