### PR TITLE
Bring README and the interop profile up to -11

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Agents don't work this way. They discover resources at runtime. They execute lon
 
 ### AAuth Protocol
 
-The authorization protocol for agent-to-resource access. Defines four resource access modes (identity-based, resource-managed, PS-asserted, federated), three proof-of-possession token types (agent, resource, auth), agent governance (missions, permissions, audit), deferred responses with clarification chat, and call chaining for multi-hop resource access.
+The authorization protocol for agent-to-resource access. Defines five resource access modes (agent identity, resource-managed, person identity, PS authorization, federated authorization), four proof-of-possession token types (agent, person, resource, auth), agent governance (missions, permissions, audit), deferred responses with clarification chat, and call chaining for multi-hop resource access.
 
 * [Editor's Copy](https://dickhardt.github.io/AAuth/draft-hardt-oauth-aauth-protocol.html)
 * [Datatracker Page](https://datatracker.ietf.org/doc/draft-hardt-oauth-aauth-protocol)
@@ -122,7 +122,7 @@ Event subscription and delivery for agents. Defines the subscribe token agents u
 
 **[interop-demo-profile.md](interop-demo-profile.md)**
 
-Non-normative guidance for implementers on the minimum live pieces needed to demonstrate end-to-end AAuth interoperability. Describes five verifiable surfaces — PS mission approval, `AAuth-Mission` presentation, resource-token issuance, auth-token issuance and presentation, and parent-mediated sub-agent handling — and which surfaces require a live PS, AS, or resource.
+Non-normative guidance for implementers on the minimum live pieces needed to demonstrate end-to-end AAuth interoperability. Describes five verifiable surfaces — PS mission approval, person-token presentation, resource-token issuance, auth-token issuance and presentation, and parent-mediated sub-agent handling — and which surfaces require a live PS, AS, or resource.
 
 ### AAuth Bootstrap Guidance (Informational)
 

--- a/interop-demo-profile.md
+++ b/interop-demo-profile.md
@@ -8,21 +8,38 @@ A minimal interop demo consists of five verifiable surfaces. Each surface can be
 
 ## Surface 1 — PS mission approval and blob response
 
-The PS exposes a `mission_endpoint`, accepts a mission proposal from the agent, applies any human-in-the-loop review, and returns the approved mission blob with the `AAuth-Mission` response header.
+The PS exposes a `mission_endpoint`, accepts a mission proposal from the agent, applies any human-in-the-loop review, and returns the approval response:
 
-The agent verifies the `s256` by computing SHA-256 over the exact response body bytes and comparing the result (base64url-encoded, unpadded) to the `s256` value in the `AAuth-Mission` header. The agent MUST store those exact bytes — no re-serialization.
+```json
+{
+  "s256": "<hash>",
+  "mission": "<base64url of the mission blob>",
+  "capabilities": ["interaction", "payment"],
+  "person_tokens": { "https://resource.example": "<person token>" }
+}
+```
 
-**What to verify:** the PS returns a valid JSON mission blob; the `s256` in the `AAuth-Mission` header matches the SHA-256 of the response body bytes.
+The agent decodes `mission`, computes SHA-256 over the decoded bytes, and compares the result (base64url-encoded, unpadded) to `s256`. Verification is a SHOULD, not a requirement, and the agent is free to store the mission however it likes — the encoded member exists so that the digest covers an unambiguous byte sequence.
 
-## Surface 2 — `AAuth-Mission` presentation and resource-token echo
+`person_tokens` is present when the proposal named `resources`; it carries one mission-scoped person token per approved resource, sparing the agent a request each.
 
-The agent sends a request to a resource including:
-- `AAuth-Mission: approver="<ps-url>"; s256="<hash>"`
-- An HTTP Message Signature covering at minimum `@method`, `@authority`, `@path`, and `signature-key`, plus `aauth-mission` when the mission header is present
+**What to verify:** the `mission` member decodes to valid JSON; `s256` matches the SHA-256 of the decoded bytes.
 
-A mission-aware resource echoes the `{approver, s256}` pair into the `mission` claim of the resource token it issues.
+## Surface 2 — Person-token issuance and presentation
 
-**What to verify:** resource token `mission.approver` matches the `AAuth-Mission` `approver`; `mission.s256` matches the `AAuth-Mission` `s256`. This can be confirmed locally by decoding the resource-token JWT — no live AS required.
+The agent obtains a person token from the PS's `person_token_endpoint`, naming the resource and, when operating under a mission, the mission:
+
+```json
+{ "resource": "https://resource.example", "mission_s256": "<hash>" }
+```
+
+The PS validates that the mission exists, is active, and belongs to this agent, and issues an `aa-person+jwt` with `aud` set to the resource, a directed `sub`, `cnf.jwk` bound to the agent's signing key, and `mission_s256` when one was named.
+
+The agent presents it to the resource via `Signature-Key: sig=jwt;jwt="<person token>"` in place of its agent token, with an HTTP Message Signature covering at minimum `@method`, `@authority`, `@path`, and `signature-key`.
+
+A resource MUST have verified a person token before it issues a resource token, and copies `ps`, `sub`, `mission_s256`, and the person token's `jti` into the resource token it issues.
+
+**What to verify:** the person token's `cnf.jwk` matches the key that signed the request; the resource token's `ps`, `sub`, and `mission_s256` match the person token, and `person_token_jti` names it. This can be confirmed locally by decoding both JWTs — no live AS required.
 
 ## Surface 3 — Resource-token issuance and issuer discovery
 
@@ -32,25 +49,36 @@ The resource signs a resource token as `aa-resource+jwt` with `iss` set to its o
 
 ## Surface 4 — Auth-token issuance and presentation
 
-The PS (three-party) or AS (four-party) issues an `aa-auth+jwt` bound to the agent's signing key:
-- `cnf.jwk` matches the agent's request signing key
-- `aud` matches the resource's identifier
-- `mission` echoes the resource-token's `mission` claim (when present)
+The agent sends the resource token to the PS's `auth_token_endpoint`. The PS resolves the person token named by `person_token_jti`, confirms the resource token's claims match what it issued, and either issues the auth token itself (three-party) or federates with the resource's AS (four-party).
 
-The agent presents the auth token via `Signature-Key: sig=jwt;jwt="<auth-token>"` on subsequent requests. The resource verifies:
+The issued `aa-auth+jwt` carries:
+
+- `cnf.jwk` matching the agent's request signing key
+- `aud` matching the resource's identifier
+- `ps` naming the person's PS, and `sub` the directed identifier
+- `mission_s256` echoing the resource token's, when present
+
+The agent presents the auth token via `Signature-Key: sig=jwt;jwt="<auth token>"` on subsequent requests. The resource verifies:
+
 1. Auth-token signature (from issuer JWKS at `{iss}/.well-known/{dwk}`)
 2. `cnf.jwk` matches the key that signed the HTTP request
 3. `aud` matches its own identifier
+4. `sub` is present, and `(iss, sub)` matches or establishes its record for this person
+
+Note that no token a resource reads carries an agent identifier. `agent_jkt` in the resource token and `cnf` in every token are the binding.
 
 ## Surface 5 — Parent-mediated sub-agent token handling
 
-1. A sub-agent calls a resource and receives a resource token bound to its own key (`agent_jkt` = thumbprint of sub-agent's key).
-2. The sub-agent passes the resource token to the parent out of band.
-3. The parent POSTs to the PS with `resource_token` (sub-agent's) and `subagent_token` (sub-agent's agent token).
-4. The PS verifies `resource_token.agent_jkt` equals the thumbprint of `subagent_token.cnf.jwk`, and `subagent_token.parent_agent` equals the parent.
-5. The issued auth token has `agent` = sub-agent identifier, `cnf.jwk` = sub-agent's key, and `act.agent` = parent agent identifier.
+1. The parent POSTs to the PS's `person_token_endpoint` with `subagent_token` (the sub-agent's agent token); the issued person token's `cnf` is the sub-agent's key. The parent passes it to the sub-agent out of band.
+2. The sub-agent presents that person token to a resource and receives a resource token bound to its own key (`agent_jkt` = thumbprint of the sub-agent's key).
+3. The sub-agent passes the resource token to the parent out of band.
+4. The parent POSTs to the PS's `auth_token_endpoint` with `resource_token` (the sub-agent's) and `subagent_token`.
+5. The PS verifies `resource_token.agent_jkt` equals the thumbprint of `subagent_token.cnf.jwk`, and `subagent_token.parent_agent` names the parent.
+6. The issued auth token has `cnf.jwk` = the sub-agent's key.
 
-**What to verify:** the resource confirms the auth token is signed with the sub-agent's key and `act.agent` names the parent.
+The sub-agent relationship is recorded by the PS, which issued both tokens and holds the `parent_agent` binding. It does not appear in any token the resource sees.
+
+**What to verify:** the resource confirms the auth token is signed with the sub-agent's key; the PS's log records the parent as the requesting agent.
 
 ## Deployment Configurations
 


### PR DESCRIPTION
Follow-on to #73. Two non-normative documents described mechanisms that PR removed.

**`interop-demo-profile.md`** — four of five surfaces were affected:

- **Surface 1** verified an `s256` carried in an `AAuth-Mission` response header against the exact response body bytes, and required the agent to store those bytes verbatim. The approval response is now an envelope with the mission base64url-encoded, the digest covers the decoded bytes, and verification is a SHOULD.
- **Surface 2** was entirely `AAuth-Mission` presentation and echoing `{approver, s256}` into the resource token. Replaced with person-token issuance and presentation, which is what the mission rides on now, including the `person_token_jti` binding.
- **Surface 4** echoed a `mission` object; now `mission_s256`, plus `ps` and `sub`, and a note that no token a resource reads carries an agent identifier.
- **Surface 5** checked `act.agent` for the parent. `act` is gone; the flow gains the step where the parent obtains the sub-agent's person token via `subagent_token`, and the parent relationship is held by the PS.

Surface 3 was unaffected.

**`README.md`** — five access modes rather than four, four token types rather than three, and the surface-2 rename.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013bmhXhYW4qa5sQsvsqeEac