### PR TITLE
Establish the AAuth Access Mode Value Registry

### DIFF
--- a/draft-hardt-aauth-r3.md
+++ b/draft-hardt-aauth-r3.md
@@ -125,7 +125,7 @@ R3 extends the `/.well-known/aauth-resource.json` document defined in AAuth Prot
 
 **`r3_vocabularies`** (OPTIONAL). A JSON object mapping vocabulary URIs to their discovery endpoints. Keys MUST be vocabulary URIs from the `urn:aauth:vocabulary:` namespace for standard vocabularies defined in this document, or third-party URI namespaces for proprietary vocabularies. Values are vocabulary-specific discovery endpoints (the MCP server URL, the OpenAPI spec URL, the gRPC reflection endpoint, etc.). A resource MAY advertise multiple vocabularies simultaneously.
 
-R3 also defines an additional value for the `access_mode` field: **`per-call`**, meaning the resource authorizes each invocation individually against that call's parameters (#per-call-proposals). A resource declares it here when every operation it exposes works that way, and on individual operations otherwise (#operation-access-annotations).
+R3 also defines an additional value for the `access_mode` field, registered in the AAuth Access Mode Value Registry ([@!I-D.hardt-oauth-aauth-protocol]): **`per-call`**, meaning the resource authorizes each invocation individually against that call's parameters (#per-call-proposals). A resource declares it here when every operation it exposes works that way, and on individual operations otherwise (#operation-access-annotations).
 
 ## Operation Identifier Scope {#operation-identifier-scope}
 
@@ -717,6 +717,14 @@ This document requests registration of the following JWT claims in the IANA JSON
 | `r3_granted` | Fully authorized operations in vocabulary format | This document |
 | `r3_per_call` | Operations authorized in principle, requiring approval of each call | This document |
 
+## AAuth Access Mode Value Registration
+
+This document requests registration of the following value in the AAuth Access Mode Value Registry established by AAuth Protocol ([@!I-D.hardt-oauth-aauth-protocol]):
+
+| Value | Description | Reference |
+|-------|-------------|-----------|
+| `per-call` | The resource authorizes each invocation individually against that call's parameters | This document |
+
 ## R3 Vocabulary Registry
 
 This specification establishes the AAuth R3 Vocabulary Registry. The initial contents are:
@@ -757,7 +765,7 @@ There are currently no known implementations.
 
 - draft-hardt-aauth-r3-02
   - Added operation access annotations: a resource states, on the operation in its own vocabulary, which credential the operation requires and whether it consumes budget. The vocabulary is where they go because it is the only description of the resource's operations an agent can read — R3 documents are PS- and AS-only. Annotations are sparse against the resource-wide `access_mode`, replace it rather than intersect with it, and stay advisory: the runtime `AAuth-Requirement` remains authoritative. Encodings defined for MCP, OpenAPI, AsyncAPI, and OData; none for gRPC, GraphQL, or WSDL, whose discovery mechanisms do not carry annotations to a generic caller.
-  - Added the `access_mode` value `per-call`, for a resource or an operation that authorizes each invocation individually against its parameters.
+  - Added the `access_mode` value `per-call`, for a resource or an operation that authorizes each invocation individually against its parameters, and registered it in the AAuth Access Mode Value Registry.
   - Renamed the auth token claim `r3_conditional` to `r3_per_call`, matching the `per-call` access mode. "Conditional" did not say what the condition was.
   - Removed the `version` field. R3 documents are content-addressed, so a revision is a different document at a different hash; `version` named nothing the hash did not, and nothing prevented two different documents carrying the same value.
 

--- a/draft-hardt-oauth-aauth-protocol.md
+++ b/draft-hardt-oauth-aauth-protocol.md
@@ -1490,7 +1490,7 @@ The agent has three operations, all of the same shape: it proposes, the person d
 | `POST {mission_endpoint}/{mission_s256}` with `action: update` | Record a change in the work (#mission-update) |
 | `POST {mission_endpoint}/{mission_s256}` with `action: completion` | Propose that the mission is finished (#mission-completion) |
 
-The `action` member is REQUIRED on requests to a mission's own URL, and a PS MUST reject a request with a missing or unrecognized `action` with `400 Bad Request`. This is the same discriminator the pending route uses (#agent-response-to-clarification), for the same reason: it makes each POST self-describing and leaves the route extensible.
+The `action` member is REQUIRED on requests to a mission's own URL, and a PS MUST reject a request with a missing or unrecognized `action` with `400 Bad Request`. This is the same discriminator the pending route uses (#agent-response-to-clarification), for the same reason: it makes each POST self-describing and leaves the route extensible. Errors at these requests are defined in (#mission-endpoint-errors).
 
 ## Mission Creation {#mission-creation}
 
@@ -1712,6 +1712,22 @@ The PS records why a mission terminated, alongside the mission rather than insid
 A termination reason MUST NOT be exposed as a mission state or used to permit a later transition.
 
 Reading a mission's status, terminating one, and querying delegation are operations for parties other than the owning agent, and belong at the `mission_control_endpoint` (#ps-metadata). They will be defined in a companion specification, along with the administrative principals that invoke them.
+
+## Mission Endpoint Errors {#mission-endpoint-errors}
+
+| Error | Status | Meaning |
+|-------|--------|---------|
+| `invalid_request` | 400 | The `{mission_s256}` path segment is malformed, or `action` is missing or unrecognized |
+| `mission_not_found` | 404 | No such mission, or it is not this agent's |
+| `mission_terminated` | 403 | This agent's mission, permanently ended (#mission-status-errors) |
+
+A PS MUST return the same status, error, body, header set, and observably equivalent timing whether the mission does not exist or the authenticated agent does not own it, and MUST NOT disclose anything about a mission before authorization succeeds. Note that the natural arrangement — checking ownership only after a successful lookup — leaks the difference in timing.
+
+The distinction matters because `mission_s256` travels in auth tokens to resources. Without this rule, a resource operator running an agent could POST a mission reference it had observed and learn from the response whether that mission was still live, reading mission status through a side channel instead of through the control plane, where the read would be authorized.
+
+A terminated mission is deliberately distinguishable: the agent that owns it already knows it exists, and needs `termination_reason` to decide whether to propose a new mission.
+
+A PS SHOULD rate-limit and security-log repeated failures, and SHOULD NOT retain raw mission references from failed requests longer than abuse correlation requires.
 
 ## Mission Status Errors {#mission-status-errors}
 
@@ -3383,6 +3399,7 @@ The following implementations are known:
   - Chain routing uses the auth token's `ps` claim. Removed the branch routing a downstream request to the upstream AS, which required the two resources to share an access server and was never stated as such.
   - `sub` MUST be unique within the issuer; `(iss, sub)` is the identifier and `tenant` is organizational context, not part of it. `sub` values from different issuers MUST NOT be matched.
   - Stated the extensibility posture: recipients ignore what they do not recognize, and no document carries a version or schema a recipient must understand.
+  - Defined the mission endpoint's error responses, including that a PS MUST answer identically — status, body, headers, and timing — whether a mission does not exist or the agent does not own it. Without that the agent surface is an existence oracle for any party that has seen a `mission_s256` in an auth token. Adopted from `draft-mcguinness-mission-aauth-management`.
   - The mission endpoint is the owning agent's surface, with three operations of one shape: `POST {mission_endpoint}` proposes a mission, and `POST {mission_endpoint}/{mission_s256}` carries `action: update` or `action: completion`. The `action` discriminator is the one the pending route already uses.
   - Added mission update. An update records a change in the work, is appended to the mission log, and is digested so the sequence is verifiable. It does not change the blob, `mission_s256`, or any token carrying it; what it changes is the context the PS evaluates against, so the mission's meaning becomes the approved blob plus its accepted updates and an audit MUST read both.
   - Moved completion off the interaction endpoint. It is a lifecycle transition, not transport: creation and completion are the same shape — the agent proposes, the person decides, clarification is available, the response is deferred — and were split across two endpoints for no structural reason. The interaction endpoint keeps `interaction`, `payment`, and `question`, which are the things the agent genuinely cannot do itself.

--- a/draft-hardt-oauth-aauth-protocol.md
+++ b/draft-hardt-oauth-aauth-protocol.md
@@ -237,7 +237,7 @@ AAuth has two dimensions: **resource access modes** and **agent governance**. Re
 
 ## Resource Access Modes
 
-AAuth supports five resource access modes. They differ in what the resource ends up knowing and which party established it — not in how much of the protocol they use. The protocol works in every mode, and adoption does not require coordination between parties. A resource MAY apply different modes to different endpoints.
+AAuth supports five resource access modes. They differ in what the resource ends up knowing and which party established it — not in how much of the protocol they use. The protocol works in every mode, and adoption does not require coordination between parties. A resource MAY apply different modes to different endpoints, and one advertising an R3 vocabulary states the mode for an individual operation there ([@?I-D.hardt-aauth-r3]).
 
 | Mode | Resource knows | Established by | Parties |
 |------|----------------|----------------|---------|
@@ -2919,7 +2919,7 @@ Fields:
 - `revocation_endpoint` (OPTIONAL): URL where authorized parties can revoke tokens (#token-revocation)
 - `jwks_uri` (REQUIRED): URL to the AS's JSON Web Key Set
 
-### Resource Metadata
+### Resource Metadata {#resource-metadata}
 
 Published at `/.well-known/aauth-resource.json`:
 
@@ -2949,7 +2949,7 @@ Fields:
 
 - `issuer` (REQUIRED): The resource's HTTPS URL. This is the value placed in the `iss` claim of resource tokens.
 - `jwks_uri` (REQUIRED when the resource issues resource tokens or makes signed calls): URL to the resource's JSON Web Key Set. A resource that only verifies agent signatures for identity-based access — issuing no resource tokens and making no signed requests of its own (e.g., as an agent in multi-hop, #multi-hop) — has no keys to publish and MAY omit `jwks_uri`.
-- `access_mode` (OPTIONAL): The credential flow the resource expects, letting an agent plan its first call without a speculative challenge. One of `agent-token` (identity-only — the agent signs with its agent token), `person-token` (the resource authorizes on the person's identity alone — the agent signs with a person token), `session-token` (resource-managed — the agent completes the resource's interaction/consent flow and receives a session token via `AAuth-Access`), or `auth-token` (the agent obtains an auth token from its PS using a resource token; the initial call MUST present a person token). Default: `agent-token`. The declaration is advisory: a resource MAY return any `AAuth-Requirement` at runtime regardless of the declared mode (#requirement-responses), and MAY apply different modes to different endpoints. An agent MAY use `access_mode` to skip resources its setup cannot satisfy — for example, a PS-less agent (no `ps` claim in its agent token) cannot complete the `auth-token` flow.
+- `access_mode` (OPTIONAL): The credential flow the resource expects, letting an agent plan its first call without a speculative challenge. This document defines `agent-token` (identity-only — the agent signs with its agent token), `person-token` (the resource authorizes on the person's identity alone — the agent signs with a person token), `session-token` (resource-managed — the agent completes the resource's interaction/consent flow and receives a session token via `AAuth-Access`), and `auth-token` (the agent obtains an auth token from its PS using a resource token; the initial call MUST present a person token). Extensions MAY define further values, which are recorded in the AAuth Access Mode Value Registry (#aauth-access-mode-value-registry); R3 ([@?I-D.hardt-aauth-r3]) defines `per-call`, for a resource that authorizes each invocation individually against that call's parameters. An agent that does not recognize a declared value proceeds as it would with no declaration, calling the resource and reading the `AAuth-Requirement` it gets back. Default: `agent-token`. The declaration is advisory: a resource MAY return any `AAuth-Requirement` at runtime regardless of the declared mode (#requirement-responses), and MAY apply different modes to different endpoints — a resource advertising an R3 vocabulary states the mode for an individual operation there ([@?I-D.hardt-aauth-r3]), and otherwise an agent learns of any variation from the runtime requirement. An agent MAY use `access_mode` to skip resources its setup cannot satisfy — for example, a PS-less agent (no `ps` claim in its agent token) cannot complete the `auth-token` flow.
 - `name` (OPTIONAL): Human-readable resource name
 - `description` (OPTIONAL): A Markdown string describing the resource, for display to users (for example, at a consent screen). Implementations MUST sanitize the Markdown before rendering to users.
 - `logo_uri` (OPTIONAL): URL to resource logo
@@ -3338,9 +3338,20 @@ This specification establishes the AAuth Platform Value Registry, used as values
 | `workload` | Headless server-class workload (backend service, CI runner, scheduled job, edge function) | This document |
 | `self-hosted` | User-controlled deployment under a domain the user controls | This document |
 
+## AAuth Access Mode Value Registry {#aauth-access-mode-value-registry}
+
+This specification establishes the AAuth Access Mode Value Registry, used as values of the `access_mode` field in resource metadata (#resource-metadata). The registry policy is Specification Required ([@!RFC8126], Section 4.6). See (#designated-expert-instructions) for instructions to the designated expert.
+
+| Value | Description | Reference |
+|-------|-------------|-----------|
+| `agent-token` | The resource authorizes on the agent's identity alone | This document |
+| `person-token` | The resource authorizes on the person's identity alone | This document |
+| `session-token` | The resource manages authorization itself and issues a session token | This document |
+| `auth-token` | The agent obtains an auth token from its PS using a resource token | This document |
+
 ## Designated Expert Instructions {#designated-expert-instructions}
 
-Registration requests for the AAuth Requirement Value, AAuth Capability Value, and AAuth Platform Value registries are evaluated by a designated expert appointed by the IESG, using the Specification Required policy ([@!RFC8126], Section 4.6).
+Registration requests for the AAuth Requirement Value, AAuth Capability Value, AAuth Platform Value, and AAuth Access Mode Value registries are evaluated by a designated expert appointed by the IESG, using the Specification Required policy ([@!RFC8126], Section 4.6).
 
 Registration requests should be sent to IANA, which will forward them to the designated expert. The expert is expected to respond within two weeks. Denials should include an explanation and, if applicable, suggestions for how the request could be revised to be successful.
 
@@ -3351,6 +3362,7 @@ A registration request must include the proposed value, a brief description of i
 - The registration does not duplicate the semantics of an existing entry without clear justification.
 - For the Requirement Value and Capability Value registries, the specification defines the protocol behavior expected of a party that declares or encounters the value, including how a party that does not understand the value behaves.
 - For the Platform Value registry, the value describes a distinct runtime context that is meaningful for display to a person at a consent screen or dashboard, and the description does not overstate the security properties the value conveys.
+- For the Access Mode Value registry, the value names a credential flow an agent can carry out, the specification defines what the agent presents and how it obtains it, and an agent that does not understand the value can still fall back to the runtime `AAuth-Requirement`.
 
 ## URI Scheme Registration
 
@@ -3383,6 +3395,8 @@ The following implementations are known:
 *Note: This section is to be removed before publishing as an RFC.*
 
 - draft-hardt-oauth-aauth-protocol-11
+  - Established the AAuth Access Mode Value Registry, seeded with `agent-token`, `person-token`, `session-token`, and `auth-token`. The `access_mode` field was described as a closed list of four, which left no room for the `per-call` value R3 defines; the registry is how the other extensible AAuth value spaces are already handled.
+  - Pointed `access_mode` at R3 operation access annotations. Two places said a resource MAY apply different modes to different endpoints without naming a mechanism for saying which.
   - Added the person token (`aa-person+jwt`), issued by a PS to identify the person to one resource. Presented via `Signature-Key` in place of the agent token. A resource MUST verify one before issuing a resource token. Lifetime capped at 1 hour, as for auth tokens.
   - Added `person_token_endpoint`, REQUIRED in PS metadata, taking `resource`, `mission_s256`, `subagent_token`, and `upstream_token`.
   - Five resource access modes instead of four, sorted by what the resource ends up knowing and which party established it: agent identity, resource-managed, person identity, PS authorization, federated authorization. A resource MAY apply different modes to different endpoints.


### PR DESCRIPTION
Closes #84.

`access_mode` was described as a closed list of four values, which left no room for the `per-call` value R3 defines (#74). A reader encountering `access_mode: per-call` would check the protocol spec, find four values, and conclude the resource was malformed.

## The registry

**Protocol spec.** Establishes the AAuth Access Mode Value Registry, Specification Required, seeded with `agent-token`, `person-token`, `session-token` and `auth-token`. This is how the other extensible AAuth value spaces are already handled — Requirement Value, Capability Value and Platform Value all have one, with a designated expert. `access_mode` was the only such space without one.

The `access_mode` field description no longer reads as a closed enumeration, and states that an agent which does not recognize a declared value proceeds as it would with no declaration.

**R3.** Registers `per-call` against itself.

## Why the base values stay in the protocol spec

They name mechanisms the base protocol defines, and a resource with no R3 vocabulary declares `access_mode: person-token` and works. Making R3 authoritative for them would mean the protocol spec cannot be implemented without reading an extension.

`per-call` is the opposite — it has no meaning without R3's per-call proposals, `r3_uri`/`r3_s256`, and the AS evaluating concrete parameters. The value belongs in the document that defines the mechanism it names.

## Also

Two places said a resource MAY apply different modes to different endpoints without naming a mechanism for saying which. R3 operation access annotations are now that mechanism, and both spots point at it.

No new `requirement` value is needed — the per-call challenge uses `requirement=auth-token` with a resource token whose `r3_uri`/`r3_s256` reference the proposal.

Both drafts build clean under `mmark` + `xml2rfc`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QvxbZKWzZyKr962fXkkGfG
