### PR TITLE
Add the i-d-template issue archive workflow

### DIFF
--- a/.github/workflows/archive.yml
+++ b/.github/workflows/archive.yml
@@ -1,0 +1,47 @@
+name: "Archive Issues and Pull Requests"
+
+on:
+  schedule:
+    - cron: '0 0 * * 0,2,4'
+  repository_dispatch:
+    types: [archive]
+  workflow_dispatch:
+    inputs:
+      archive_full:
+        description: 'Recreate the archive from scratch'
+        default: false
+        type: boolean
+
+jobs:
+  build:
+    name: "Archive Issues and Pull Requests"
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: read
+      pull-requests: read
+    steps:
+    - name: "Checkout"
+      uses: actions/checkout@v6
+
+    # Note: No caching for this build!
+
+    - name: "Update Archive"
+      uses: martinthomson/i-d-template@v1
+      env:
+        ARCHIVE_FULL: ${{ inputs.archive_full }}
+      with:
+        make: archive
+        token: ${{ github.token }}
+
+    - name: "Update GitHub Pages"
+      uses: martinthomson/i-d-template@v1
+      with:
+        make: gh-archive
+        token: ${{ github.token }}
+
+    - name: "Save Archive"
+      uses: actions/upload-artifact@v6
+      with:
+        name: archive
+        path: archive.json


### PR DESCRIPTION
Adds `.github/workflows/archive.yml` from the current i-d-template. It runs Sun/Tue/Thu at 00:00 UTC (and on manual dispatch) and writes `archive.json`, `issues.html`, and `issues.js` to gh-pages, so the issue and PR history has a static copy we control and the "saved issues" link on the gh-pages index resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BdKzq6t78QufwReZ5vDoWs